### PR TITLE
Added Glyphs to accomidate color blind people.

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -53,13 +53,13 @@
       <div class="horizontalcenterwrapper" style="grid-row: 2; grid-column: 1/3;">
         <div id="gridsizecontainer">
           <div class="sizeinput">
-            <input type="number" min="1" max="32" value="8">
+            <input id="width" type="number" min="1" max="32" value="8">
           </div>
     
           <div class="griditemsizecontainer">x</div>
     
           <div class="sizeinput">
-            <input type="number" min="1" max="32" value="8">
+            <input id="height" type="number" min="1" max="32" value="8">
           </div>
         </div>
       </div>
@@ -94,18 +94,18 @@
       </div>
       <div class="horizontalcenterwrapper" style="grid-row: 7; grid-column: 1/3;">
         <div id="colorselector" style="border: 2px solid black;">
-          <div class="tile c0"></div>
-          <div class="tile c1"></div>
-          <div class="tile c2"></div>
-          <div class="tile c3"></div>
-          <div class="tile c4"></div>
-          <div class="tile c5"></div>
-          <div class="tile c-1"></div>
-          <div class="tile c6"></div>
-          <div class="tile c7"></div>
-          <div class="tile c8"></div>
-          <div class="tile c9"></div>
-          <div class="tile c10"></div>
+          <canvas class="tile c0" width="40px" height="40px"></canvas>
+          <canvas class="tile c1" width="40px" height="40px"></canvas>
+          <canvas class="tile c2" width="40px" height="40px"></canvas>
+          <canvas class="tile c3" width="40px" height="40px"></canvas>
+          <canvas class="tile c4" width="40px" height="40px"></canvas>
+          <canvas class="tile c5" width="40px" height="40px"></canvas>
+          <canvas class="tile c-1" width="40px" height="40px"></canvas>
+          <canvas class="tile c6" width="40px" height="40px"></canvas>
+          <canvas class="tile c7" width="40px" height="40px"></canvas>
+          <canvas class="tile c8" width="40px" height="40px"></canvas>
+          <canvas class="tile c9" width="40px" height="40px"></canvas>
+          <canvas class="tile c10" width="40px" height="40px"></canvas>
         </div>
       </div>
 

--- a/website/index.html
+++ b/website/index.html
@@ -108,6 +108,14 @@
           <canvas class="tile c10" width="40px" height="40px"></canvas>
         </div>
       </div>
+      <div class="horizontalcenterwrapper" style="grid-row: 8; grid-column: 1/3;">
+        <div id="puzzlediv"><br />Puzzle JSON:&nbsp; (cols default to 8; rows default to 8; nonblank tiles are saved)<br />
+          <textarea id="puzzlevalue" rows="3" cols="60"></textarea>
+        </div>
+      </div>
+      <div class="horizontalcenterwrapper" style="grid-row: 9; grid-column: 1/3;">
+        <div id="puzerr" style="color:red;"></div>
+      </div>
 
       <div id="helpdiamondhover" style="grid-row: 1; grid-column: 2; justify-self: right;"></div>
       <div id="helpdiamond" style="grid-row: 1; grid-column: 2; justify-self: right;"></div>

--- a/website/main.py
+++ b/website/main.py
@@ -1,0 +1,285 @@
+import numpy as np
+
+# This can be any shape or size as long as it is rectangular
+# 0's are empty space
+# -1's are immovable objects
+# Any other number is a specific block. Matching #'s are the same block type.
+# All block numbers must be positive integers
+
+# 10x10 array to copy as needed
+# puzzleBoard = np.array([[0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+#                         [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+#                         [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+#                         [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+#                         [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+#                         [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+#                         [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+#                         [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+#                         [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+#                         [0, 0, 0, 0, 0, 0, 0, 0, 0, 0]])
+
+puzzleBoard = np.array([[0, 0, 0, 1, 2, 3, 4, 2, 0],
+                        [0, 0, 0, 5, 1, 2, 3, 4, 0],
+                        [0, 0, 0, 3, 4, 5, 1, 6, 0],
+                        [7, 7, 5, 6, 3, 4, 5, 1, 7],
+                        [-1, -1, -1, 3, 4, 5, 1, 6, 2],
+                        [-1, -1, -1, 5, 1, 2, 3, 4, 2]])
+
+
+# Board needs to be saved for JSON before any moves are made.
+boardstr = str(puzzleBoard).replace('\n', ",").replace("[ ", "[").replace(" ", ",").replace(",,", ",")
+
+# Stores the solution to the puzzle
+movesToSolve = []
+
+
+# Recursive function that solves the puzzle
+def solve():
+    global puzzleBoard
+    global movesToSolve
+    checkForWin()
+
+    # For every row in the puzzle
+    for y in range(puzzleBoard.shape[0]):
+        # For every column in the puzzle
+        for x in range(puzzleBoard.shape[1]):
+            # If the piece is a movable piece
+            if puzzleBoard[y][x] > 0:
+                # Check if the piece can be moved up or right
+                # There is no need to check down or left as those would be
+                # another piece's up or right respectively
+                if checkValidMove(y, x, y - 1, x):  # Up
+                    executeMove(y, x, y - 1, x)
+                if checkValidMove(y, x, y, x + 1):  # Right
+                    executeMove(y, x, y, x + 1)
+
+
+# Checks if a move is a valid move
+# Input coordinates y1, x1 to be swapped with y2, x2
+def checkValidMove(y1, x1, y2, x2):
+    global puzzleBoard
+
+    # If the move is out of bounds
+    if y2 < 0 or x2 >= puzzleBoard.shape[1]:
+        return False
+
+    # If the move is swapping with air or a blocker
+    if puzzleBoard[y2, x2] < 1:
+        return False
+
+    # Swap the 2 spots on the puzzle board
+    tempValue = puzzleBoard[y1, x1]
+    puzzleBoard[y1, x1] = puzzleBoard[y2, x2]
+    puzzleBoard[y2, x2] = tempValue
+
+    # Check if the move results in any blocks being removed
+    isMoveValid = checkIfBlocksRemoved(y1, x1) or checkIfBlocksRemoved(y2, x2)
+
+    # Swap the pieces back
+    tempValue = puzzleBoard[y1, x1]
+    puzzleBoard[y1, x1] = puzzleBoard[y2, x2]
+    puzzleBoard[y2, x2] = tempValue
+
+    return isMoveValid
+
+
+# Takes an x and y coordinate of the puzzle board
+# Checks if that piece should be removed
+def checkIfBlocksRemoved(y, x):
+    global puzzleBoard
+
+    # If it matches with the 2 blocks above it
+    if y - 2 >= 0:
+        if puzzleBoard[y - 2, x] == puzzleBoard[y - 1, x] == puzzleBoard[y, x]:
+            return True
+    # If it matches the block above it and the block below it
+    if y - 1 >= 0 and y + 1 < puzzleBoard.shape[0]:
+        if puzzleBoard[y - 1, x] == puzzleBoard[y, x] == puzzleBoard[y + 1, x]:
+            return True
+    # If it matches with the 2 blocks below it
+    if y + 2 < puzzleBoard.shape[0]:
+        if puzzleBoard[y, x] == puzzleBoard[y + 1, x] == puzzleBoard[y + 2, x]:
+            return True
+
+    # If it matches with the 2 blocks to the left of it
+    if x - 2 >= 0:
+        if puzzleBoard[y, x - 2] == puzzleBoard[y, x - 1] == puzzleBoard[y, x]:
+            return True
+    # If it matches the block to the right and left of it
+    if x - 1 >= 0 and x + 1 < puzzleBoard.shape[1]:
+        if puzzleBoard[y, x - 1] == puzzleBoard[y, x] == puzzleBoard[y, x + 1]:
+            return True
+    # If it matches with the 2 blocks to the right of it
+    if x + 2 < puzzleBoard.shape[1]:
+        if puzzleBoard[y, x] == puzzleBoard[y, x + 1] == puzzleBoard[y, x + 2]:
+            return True
+
+    # If none of the moves resulted in blocks being removed
+    return False
+
+
+# Executes a given move on the board
+# Input coordinates y1, x1 to be swapped with y2, x2
+def executeMove(y1, x1, y2, x2):
+    global puzzleBoard
+    global movesToSolve
+
+    # Add the move to the move list
+    movesToSolve.append([[y1,x1], [y2,x2]])
+    # Save the current board state
+    oldBoardState = puzzleBoard.copy()
+
+    # Execute the move and recalculate the new puzzle board
+    tempValue = puzzleBoard[y1, x1]
+    puzzleBoard[y1, x1] = puzzleBoard[y2, x2]
+    puzzleBoard[y2, x2] = tempValue
+    recalculateBoard()
+
+    # Attempt to do the next move
+    solve()
+
+    # If this line was reached, the move was incorrect, so revert to the old board state
+    puzzleBoard = oldBoardState
+    # And remove the move from the move list
+    movesToSolve.pop()
+
+
+# Check if there are any pieces that need to be removed and removes them
+# Then rearranges the board to account for pieces falling
+# Recursively calls itself until no pieces move
+def recalculateBoard():
+    # Get what blocks need to be removed
+    blocksToRemove = checkWhatBlocksToRemove()
+    # If there are blocks to remove
+    if blocksToRemove.any():
+        # Remove the blocks
+        removeGivenBlocks(blocksToRemove)
+        # Make all the blocks fall down
+        calculateGravity()
+        # Restart this process
+        recalculateBoard()
+
+
+# Iterates over the whole puzzle board and returns what blocks need to be removed
+# Return: An 2d array of 0s and 1s where 1s represent the positions where blocks need to be removed
+def checkWhatBlocksToRemove():
+    global puzzleBoard
+
+    blocksToRemove = np.zeros(puzzleBoard.shape)
+
+    # For every row in the puzzle
+    for y in range(puzzleBoard.shape[0]):
+        # For every column in the puzzle
+        for x in range(puzzleBoard.shape[1]):
+            # If the piece is a removable piece
+            if puzzleBoard[y][x] > 0:
+                # We only have to check for these 2 because all the other circumstances will be checked
+                # in another piece's 2 above or 2 to the right
+
+                # Check if it can be matched with the 2 pieces above it
+                if y - 2 >= 0:
+                    if puzzleBoard[y - 2, x] == puzzleBoard[y - 1, x] == puzzleBoard[y, x]:
+                        # Mark the pieces to be removed
+                        blocksToRemove[y - 2, x] = 1
+                        blocksToRemove[y - 1, x] = 1
+                        blocksToRemove[y, x] = 1
+
+                # Check if it can be matched with the 2 pieces to the right of it
+                if x + 2 < puzzleBoard.shape[1]:
+                    if puzzleBoard[y, x] == puzzleBoard[y, x + 1] == puzzleBoard[y, x + 2]:
+                        # Mark the pieces to be removed
+                        blocksToRemove[y, x] = 1
+                        blocksToRemove[y, x + 1] = 1
+                        blocksToRemove[y, x + 2] = 1
+
+    return blocksToRemove
+
+
+# Takes an array of 1's and 0's
+# Removes all blocks from the puzzle board where the given array has a 1 in the same position
+# Used with checkWhatBlocksToRemove()
+def removeGivenBlocks(blocksToRemove):
+    global puzzleBoard
+
+    # For every row in the puzzle
+    for y in range(puzzleBoard.shape[0]):
+        # For every column in the puzzle
+        for x in range(puzzleBoard.shape[1]):
+            # If the piece is marked to be removed
+            if blocksToRemove[y][x] == 1:
+                # Remove the piece
+                puzzleBoard[y][x] = 0
+
+
+# Makes all blocks that need to fall down in the puzzle board fall down
+# Moves all blocks with air under them down 1
+# Recursively calls itself until no blocks move
+# Blockers (-1s) do not fall
+def calculateGravity():
+    global puzzleBoard
+
+    didBlocksMove = False
+
+    # For every row in the puzzle (bottom to top, skipping the bottom most row)
+    for y in range(puzzleBoard.shape[0] - 2, -1, -1):
+        # For every column in the puzzle
+        for x in range(puzzleBoard.shape[1]):
+            # If the piece is effected by gravity
+            if puzzleBoard[y][x] > 0:
+                # If there is air below it
+                if puzzleBoard[y + 1][x] == 0:
+                    # Move it down to that block
+                    puzzleBoard[y + 1][x] = puzzleBoard[y][x]
+                    puzzleBoard[y][x] = 0
+                    didBlocksMove = True
+
+    # If any blocks moved, check if any more gravity is needed
+    if didBlocksMove:
+        calculateGravity()
+
+
+# Checks if the board is in a winning state and if it is, print the solution
+def checkForWin():
+    global puzzleBoard
+    global movesToSolve
+    global boardstr
+    
+    width = puzzleBoard.shape[1]
+    height = puzzleBoard.shape[0]
+
+    if np.max(puzzleBoard) < 1:
+        #boardstr = str(puzzleBoard).replace('\n', ",").replace("[ ", "[").replace(" ", ",").replace(",,", ",")
+        movestr = str(movesToSolve)
+        outputJSONString = '{"width":' + str(width)
+        outputJSONString += ', "height":' + str(height)
+        outputJSONString += ', "moves":' + str(len(movesToSolve))
+        outputJSONString += ', "swaps":' + movestr
+        outputJSONString += ', "board":' + boardstr + '}'
+        # Build JSON string
+        # For every row in the puzzle
+        #for y in range(puzzleBoard.shape[0]):
+        #    # For every column in the puzzle
+        #    for x in range(puzzleBoard.shape[1]):
+        print('The solution is:\n')
+
+        for move in movesToSolve:
+            print(f'Swap: {move[0]} with {move[1]}')
+
+        print('\n')
+        print('Puzzle JSON Solution: (paste into website)\n')
+        print(outputJSONString + '\n')
+
+        print('\nMoves are coordinates with 0,0 being the top left; '
+              '1,0 being below it; '
+              'and 0,1 being to the right of 0,0')
+
+        quit()
+
+
+# Main
+if __name__ == '__main__':
+    solve()
+
+    # If the code got here the puzzle is impossible
+    print('There is no solution')
+

--- a/website/solve.js
+++ b/website/solve.js
@@ -196,6 +196,22 @@ function executeMove(y1, x1, y2, x2) {
     storedBoards.pop();
 }
 
+// Executes a given solution found move on the board
+// Input coordinates y1, x1 to be swapped with y2, x2
+function executeSolvedMove(y1, x1, y2, x2) {
+  if (checkValidMove(y1, x1, y2, x2)) {
+    // Add the move to the move list (for highlight)
+    movesToSolve.push([[y1, x1, dict[puzzleBoard[y1][x1]]], [y2, x2, dict[puzzleBoard[y2][x2]]]]);
+    // Add board state to the saved boards
+    storedBoards.push(JSON.parse(JSON.stringify(puzzleBoard)));
+    // Execute the move and recalculate the new puzzle board
+    let tempValue = puzzleBoard[y1][x1];
+    puzzleBoard[y1][x1] = puzzleBoard[y2][x2];
+    puzzleBoard[y2][x2] = tempValue;
+    recalculateBoard();
+  } // Invalid moves get silently discarded
+}
+
 // Check if there are any pieces that need to be removed and removes them
 // Then rearranges the board to account for pieces falling
 // Recursively calls itself until no pieces move

--- a/website/solve.js
+++ b/website/solve.js
@@ -186,7 +186,7 @@ function executeMove(y1, x1, y2, x2) {
     // Attempt to do the next move
     solve();
 
-    // If this line was reached, the move was inccorect, so revert to the old board state
+    // If this line was reached, the move was incorrect, so revert to the old board state
     puzzleBoard.length = 0;
     for (let index = 0; index < height; index++) {
         puzzleBoard.push(oldBoardState[index]);

--- a/website/styles.css
+++ b/website/styles.css
@@ -112,7 +112,7 @@ input[type=number] {
 .c5 {background-color: #FF8C00;}
 .c5:hover {background-color: #C26A00;}
 
-.c6 {background-color: #FFDD00;}
+.c6 {background-color: #FFDD00;}  /* rgb(230,187,150) is easier to read */
 .c6:hover {background-color: #CCB100;}
 
 .c7 {background-color: #8DDC0D;}

--- a/website/styles.css
+++ b/website/styles.css
@@ -48,6 +48,11 @@ textarea {
   margin-bottom: 20px;
 }
 
+#puzzlevalue {
+  resize: auto;
+  margin-bottom: 0px;
+}
+
 /* The wrapper around the width height and x to make them look proper */
 #gridsizecontainer {
   display: inline-grid;

--- a/website/website.js
+++ b/website/website.js
@@ -411,9 +411,9 @@ async function exportBoard(e) {
   exportButton.removeAttribute("disabled");
 
   // Send to text area too if available (vending machine style)
-  let puzerr = document.getElementById("puzerr");
-  if (puzerr !== null) {
-    puzerr.innerHTML = outputJSONString;
+  let puzval = document.getElementById("puzzlevalue");
+  if (puzval !== null) {
+    puzval.value = outputJSONString;
   }
 }
 

--- a/website/website.js
+++ b/website/website.js
@@ -86,10 +86,13 @@ function updateGridSize() {
   // Add tiles
   if (width * height > oldWidth * oldHeight) {
     for (let i = 0; i < (width * height - oldWidth * oldHeight); i++) {
-      const tile = document.createElement("div");
+      const tile = document.createElement("canvas");
+      tile.width = 40;
+      tile.height = 40;
       tile.classList.add("tile", "c0");
       tile.addEventListener("mousedown", cChange);
       tile.addEventListener("mouseenter", mouseEnterTile)
+      drawGlyphByNum(0, tile);
       tileContainer.appendChild(tile);
     }
   }
@@ -117,7 +120,14 @@ function cChange(e) {
   }
 
   if (selectedColor !== null) {
-    e.target.classList.replace("c" + getCNumber(e.target), "c" + selectedColor);
+    // If selected color is set on current tile, make it blank/toggle it
+    if (Number(getCNumber(e.target)) == Number(selectedColor)) {
+      e.target.classList.replace("c" + getCNumber(e.target), "c0");
+      drawGlyphByNum(0, e.target);
+    } else {
+      e.target.classList.replace("c" + getCNumber(e.target), "c" + selectedColor);
+      drawGlyphByNum(selectedColor, e.target);
+    }
     return;
   }
 
@@ -139,6 +149,7 @@ function cChange(e) {
   }
 
   e.target.classList.replace("c" + cNumber, "c" + newCNumber);
+  drawGlyphByNum(newCNumber, e.target);
 }
 
 // Changes the selected color to the clicked color
@@ -167,6 +178,7 @@ function cSelect(e) {
 
   // Add selected state to the clicked color
   e.target.classList.toggle("selected", true);
+  drawGlyphByNum(targetColor, e.target);
 }
 
 // Returns the value of the current class
@@ -207,6 +219,7 @@ function clearGrid(e) {
     let cNumber = Number(getCNumber(tile));
     // Replace its c class with c0
     tile.classList.replace("c" + cNumber, "c0");
+    drawGlyphByNum(0, tiles[index]);
   }
 }
 
@@ -344,6 +357,7 @@ function updateBoardState() {
     // Replace its c class with the c Number from the stored board state
     let newCNumber = storedBoards[currentStep][Math.floor(index / width)][index % width];
     tile.classList.replace("c" + cNumber, "c" + newCNumber);
+    drawGlyphByNum(newCNumber, tile);
   }
 
   highlightMove("8px");
@@ -447,3 +461,872 @@ async function importBoard() {
 function sleep(ms) {
   return new Promise(resolve => setTimeout(resolve, ms));
 }
+
+// Get color pallet from CSS
+function getCssBg(tileCSS = ".c0") {
+  let cssBg = '';
+
+  // Since "styles.css" is external to the "index.html", 
+  // document.styleSheets[0].cssRules is only website accessible & not via file:///
+  try {
+    styleRules = document.styleSheets[0].cssRules;  // use Index = 0 since only 1 stylesheet
+    // Since CSS rules can be all over the place, only safe thing to do is iterate.
+    for (let yindex = 0; yindex < styleRules.length; yindex++) {
+      if (styleRules[yindex].selectorText == tileCSS) {
+        cssBg = styleRules[yindex].style.getPropertyValue("background-color");
+        if (cssBg.length > 0) {
+          cssBg = cssBg.replace("rgb(", "rgba(").replace(")", ", 1.0)");
+        }
+      }
+    }
+  } catch (err) {
+    console.log(err.name + ": " + err.message);
+    return "";
+  }
+  //console.log(cssBg);
+  return cssBg;
+}
+
+// Handle single and multiple elements
+function drawGlyphList(elemList = document.getElementsByClassName('tile c0'), gcb = drawGlyph0) {
+  if (elemList.toString() == "[object HTMLCanvasElement]") {
+    // Single element
+    gcb(elemList);
+  } else if (elemList.toString() == "[object HTMLCollection]") {
+    // Multiple elements
+    for (let i=0; i < elemList.length; i++) {
+      drawGlyphList(elemList[i], gcb);
+    }
+  }
+}
+
+// Return a single element by ID or CSS Class; prefer class.
+function domClassOrId(glyphStr = 'tile c0') {
+  const domElem = document.getElementById(glyphStr);
+  const domElemList = document.getElementsByClassName(glyphStr);
+
+  if (domElem === null || domElemList.length > 0) {
+    return domElemList; // Use with drawGlyphList above
+  }
+  return domElem;
+}
+
+// Make it easier to draw a specific glyph or set of glyphs
+function drawGlyphByNum(glyphNum = 0, e) {
+  // Currently only 12 possible glyphs; other numbers ignored & logged.
+  if (e === undefined) {
+    e = domClassOrId('tile c' + glyphNum);
+  }
+  switch (glyphNum) {
+  case -1:
+    drawGlyphList(e, drawGlyph_1);
+    break;
+  case 0:
+    drawGlyphList(e, drawGlyph0);
+    break;
+  case 1:
+    drawGlyphList(e, drawGlyph1);
+    break;
+  case 2:
+    drawGlyphList(e, drawGlyph2);
+    break;
+  case 3:
+    drawGlyphList(e, drawGlyph3);
+    break;
+  case 4:
+    drawGlyphList(e, drawGlyph4);
+    break;
+  case 5:
+    drawGlyphList(e, drawGlyph5);
+    break;
+  case 6:
+    drawGlyphList(e, drawGlyph6);
+    break;
+  case 7:
+    drawGlyphList(e, drawGlyph7);
+    break;
+  case 8:
+    drawGlyphList(e, drawGlyph8);
+    break;
+  case 9:
+    drawGlyphList(e, drawGlyph9);
+    break;
+  case 10:
+    drawGlyphList(e, drawGlyph10);
+    break;
+  default: // Error condition
+    console.log(String(glyphNum));
+  }
+}
+
+// blank black glyph
+function drawGlyph_1(elem = document.getElementById('tile c-1')) {
+  if (elem === undefined || elem === null) return;
+  var curGlyph = elem; // 1 specific tile
+  var context = curGlyph.getContext('2d');
+
+  const centerX = 0;
+  const centerY = -1 * (curGlyph.height / 4);
+  const radius = (curGlyph.height / 6);
+  const linelen = 3 * (curGlyph.height / 8);
+  const lineWidth = (curGlyph.height / 16);
+  const glyphForeground = 'rgba(255,255,255,1.0)';
+  let glyphBackground = 'rgba(0,0,0,1.0)';
+  let cssBg = getCssBg(".c-1");
+
+  if (cssBg.length > 0) glyphBackground = cssBg;
+
+  context.clearRect(0, 0, window.innerWidth,window.innerHeight);
+
+  context.fillStyle = glyphBackground;
+  context.fillRect(0,0,window.innerWidth,window.innerHeight);
+
+  context.save();
+  context.translate(curGlyph.width / 2, curGlyph.height / 2);
+
+  context.scale(1.0, 1.0);
+  context.lineWidth = lineWidth;
+  context.strokeStyle = glyphForeground;
+
+  // make alpha solid (the color doesn't matter)
+  context.fillStyle = 'rgba(255,255,255,0.0)';
+
+  // change composite mode and fill
+  context.globalCompositeOperation = 'destination-out';
+  context.fill();
+  context.restore();
+
+  // reset composite mode to default
+}
+
+// blank white glyph
+function drawGlyph0(elem = document.getElementById('tile c0')) {
+  if (elem === undefined || elem === null) return;
+  var curGlyph = elem; // 1 specific tile
+  var context = curGlyph.getContext('2d');
+
+  const centerX = 0;
+  const centerY = -1 * (curGlyph.height / 4);
+  const radius = (curGlyph.height / 6);
+  const linelen = 3 * (curGlyph.height / 8);
+  const lineWidth = (curGlyph.height / 16);
+  const glyphForeground = 'rgba(255,255,255,1.0)';
+  let glyphBackground = 'rgba(255,255,255,1.0)';
+  let cssBg = getCssBg(".c0");
+
+  if (cssBg.length > 0) glyphBackground = cssBg;
+
+  context.clearRect(0, 0, window.innerWidth,window.innerHeight);
+
+  context.fillStyle = glyphBackground;
+  context.fillRect(0,0,window.innerWidth,window.innerHeight);
+
+  context.save();
+  context.translate(curGlyph.width / 2, curGlyph.height / 2);
+
+  context.scale(1.0, 1.0);
+  context.lineWidth = lineWidth;
+  context.strokeStyle = glyphForeground;
+
+  // make alpha solid (the color doesn't matter)
+  context.fillStyle = 'rgba(255,255,255,0.0)';
+
+  // change composite mode and fill
+  context.globalCompositeOperation = 'destination-out';
+  context.fill();
+  context.restore();
+
+  // reset composite mode to default
+}
+
+// 2 hunting bows against a circle
+function drawGlyph1(elem = document.getElementById('tile c1')) {
+  if (elem === undefined || elem === null) return;
+  var curGlyph = elem; // 1 specific tile
+  var context = curGlyph.getContext('2d');
+
+  const centerX = 0;
+  const centerY = -1 * (curGlyph.height / 4);
+  const radius = (curGlyph.height / 6);
+  const linelen = 3 * (curGlyph.height / 8);
+  const lineWidth = (curGlyph.height / 16);
+  const glyphForeground = 'rgba(255,255,255,1.0)';
+  let glyphBackground = 'rgba(90,190,245,1.0)';
+  let cssBg = getCssBg(".c1");
+
+  if (cssBg.length > 0) glyphBackground = cssBg;
+
+  context.clearRect(0, 0, window.innerWidth,window.innerHeight);
+
+  context.fillStyle = glyphBackground;
+  context.fillRect(0,0,window.innerWidth,window.innerHeight);
+
+  context.save();
+  context.translate(curGlyph.width / 2, curGlyph.height / 2);
+
+  context.scale(1.0, 1.0);
+  context.lineWidth = lineWidth;
+  context.strokeStyle = glyphForeground;
+
+  // Top arc
+  context.beginPath();
+  context.moveTo(linelen * -1, centerY);
+  context.quadraticCurveTo(0, centerY+(curGlyph.height / 4), linelen, centerY);
+  context.stroke();
+  context.closePath();
+
+  // Bottom arc
+  context.beginPath();
+  context.moveTo(linelen * -1, (centerY*-1));
+  context.quadraticCurveTo(0, centerY+(curGlyph.height / 4), linelen, (centerY*-1));
+  context.stroke();
+  context.closePath();
+
+  // Small center circle
+  context.beginPath();
+  context.arc(0, 0, radius/2, 0, 2.0 * Math.PI, false);
+  context.stroke();
+  context.closePath();
+
+  // make alpha solid (the color doesn't matter)
+  context.fillStyle = 'rgba(255,255,255,0.0)';
+
+  // change composite mode and fill
+  context.globalCompositeOperation = 'destination-out';
+  context.fill();
+  context.restore();
+
+  // reset composite mode to default
+}
+
+// Narrow orbit
+function drawGlyph2(elem = document.getElementById('tile c2')) {
+  if (elem === undefined || elem === null) return;
+  var curGlyph = elem; // 1 specific tile
+  var context = curGlyph.getContext('2d');
+
+  const centerX = 0;
+  const centerY = -1 * (curGlyph.height / 4);
+  const radius = (curGlyph.height / 6);
+  const linelen = 3 * (curGlyph.height / 8);
+  const lineWidth = (curGlyph.height / 16);
+  const glyphForeground = 'rgba(255,255,255,1.0)';
+  let glyphBackground = 'rgba(97,86,129,1.0)';
+  let cssBg = getCssBg(".c2");
+
+  if (cssBg.length > 0) glyphBackground = cssBg;
+
+  context.clearRect(0, 0, window.innerWidth,window.innerHeight);
+
+  context.fillStyle = glyphBackground;
+  context.fillRect(0,0,window.innerWidth,window.innerHeight);
+
+  context.save();
+  context.translate(curGlyph.width / 2, curGlyph.height / 2);
+
+  context.scale(1.0, 1.0);
+  context.lineWidth = lineWidth;
+  context.strokeStyle = glyphForeground;
+
+  // Large top arc
+  context.beginPath();
+  context.moveTo(linelen * -1, centerY+(curGlyph.height / 4)-(radius/2));
+  context.quadraticCurveTo(0, centerY*0.75, linelen, centerY+(curGlyph.height / 4)-(radius/2));
+  context.stroke();
+  context.closePath();
+
+  // Large bottom arc
+  context.beginPath();
+  context.moveTo(linelen * -1, centerY+(curGlyph.height / 4)+(radius/2));
+  context.quadraticCurveTo(0, (centerY*-1)*0.75, linelen, centerY+(curGlyph.height / 4)+(radius/2));
+  context.stroke();
+  context.closePath();
+
+  // Small left arc
+  context.beginPath();
+  // Arc length should be slightly reduced, but I don't know the formula
+  context.arc(linelen * -1 + context.lineWidth/4, 0, radius/2, 0.5 * Math.PI, 1.5 * Math.PI, false);
+  context.stroke();
+  context.closePath();
+
+  // Small right arc
+  context.beginPath();
+  context.arc(linelen - context.lineWidth/4, 0, radius/2, 0.5 * Math.PI, 1.5 * Math.PI, true);
+  context.stroke();
+  context.closePath();
+
+  // Large left arc
+  context.beginPath();
+  context.moveTo(centerY+(curGlyph.height / 4)-(radius/2), linelen * -1);
+  context.quadraticCurveTo(centerY*0.75, 0, centerY+(curGlyph.height / 4)-(radius/2), linelen);
+  context.stroke();
+  context.closePath();
+
+  // Large right arc
+  context.beginPath();
+  context.moveTo(centerY+(curGlyph.height / 4)+(radius/2), linelen * -1);
+  context.quadraticCurveTo((centerY*-1)*0.75, 0, centerY+(curGlyph.height / 4)+(radius/2), linelen);
+  context.stroke();
+  context.closePath();
+
+  // Small top arc
+  context.beginPath();
+  context.arc(0, linelen * -1 + context.lineWidth/4, radius/2, 0.0 * Math.PI, 1.0 * Math.PI, true);
+  context.stroke();
+  context.closePath();
+
+  // Small bottom arc
+  context.beginPath();
+  context.arc(0, linelen * 1 - context.lineWidth/4, radius/2, 0.0 * Math.PI, 1.0 * Math.PI, false);
+  context.stroke();
+  context.closePath();
+
+  // make alpha solid (the color doesn't matter)
+  context.fillStyle = 'rgba(255,255,255,0.0)';
+
+  // change composite mode and fill
+  context.globalCompositeOperation = 'destination-out';
+  context.fill();
+  context.restore();
+
+  // reset composite mode to default
+}
+
+// Opposing Sunsets
+function drawGlyph3(elem = document.getElementById('tile c3')) {
+  if (elem === undefined || elem === null) return;
+  var curGlyph = elem; // 1 specific tile
+  var context = curGlyph.getContext('2d');
+
+  const centerX = 0;
+  const centerY = -1 * (curGlyph.height / 8);
+  const radius = (curGlyph.height / 6);
+  const linelen = 3 * (curGlyph.height / 8);
+  const lineWidth = (curGlyph.height / 16);
+  const glyphForeground = 'rgba(255,255,255,1.0)';
+  let glyphBackground = 'rgba(217,50,145,1.0)';
+  let cssBg = getCssBg(".c3");
+
+  if (cssBg.length > 0) glyphBackground = cssBg;
+
+  context.clearRect(0, 0, window.innerWidth,window.innerHeight);
+
+  context.fillStyle = glyphBackground;
+  context.fillRect(0,0,window.innerWidth,window.innerHeight);
+
+  context.save();
+  context.translate(curGlyph.width / 2, curGlyph.height / 2);
+
+  context.scale(1.0, 1.0);
+
+  // define the arc path
+  context.beginPath();
+  context.arc(centerX, centerY, radius, 0, 1.0 * Math.PI, true);
+  context.moveTo(linelen * -1, centerY);
+  context.lineTo(linelen, centerY);
+  context.moveTo(linelen * -1, centerY+(curGlyph.height / 4));
+  context.lineTo(linelen, centerY+(curGlyph.height / 4));
+  context.arc(centerX, centerY+(curGlyph.height / 4), radius, 0, 1.0 * Math.PI, false);
+
+  // stroke it
+  context.lineWidth = lineWidth;
+  context.strokeStyle = glyphForeground;
+  context.stroke();
+
+  // make alpha solid (the color doesn't matter)
+  context.fillStyle = 'rgba(255,255,255,0.0)';
+
+  // change composite mode and fill
+  context.globalCompositeOperation = 'destination-out';
+  context.fill();
+  context.restore();
+
+  // reset composite mode to default
+}
+
+// Wide orbit
+function drawGlyph4(elem = document.getElementById('tile c4')) {
+  if (elem === undefined || elem === null) return;
+  var curGlyph = elem; // 1 specific tile
+  var context = curGlyph.getContext('2d');
+
+  const centerX = 0;
+  const centerY = -1 * (curGlyph.height / 4);
+  const radius = (curGlyph.height / 6);
+  const linelen = 3 * (curGlyph.height / 8);
+  const lineWidth = (curGlyph.height / 16);
+  const glyphForeground = 'rgba(255,255,255,1.0)';
+  let glyphBackground = 'rgba(172,56,96,1.0)';
+  let cssBg = getCssBg(".c4");
+
+  if (cssBg.length > 0) glyphBackground = cssBg;
+
+  context.clearRect(0, 0, window.innerWidth,window.innerHeight);
+
+  context.fillStyle = glyphBackground;
+  context.fillRect(0,0,window.innerWidth,window.innerHeight);
+
+  context.save();
+  context.translate(curGlyph.width / 2, curGlyph.height / 2);
+
+  context.scale(1.0, 1.0);
+  context.lineWidth = lineWidth;
+  context.strokeStyle = glyphForeground;
+
+  // Large top arc
+  context.beginPath();
+  context.moveTo(linelen * -1, centerY+(curGlyph.height / 4)-(radius/2));
+  context.quadraticCurveTo(0, centerY*1.5, linelen, centerY+(curGlyph.height / 4)-(radius/2));
+  context.stroke();
+  context.closePath();
+
+  // Large bottom arc
+  context.beginPath();
+  context.moveTo(linelen * -1, centerY+(curGlyph.height / 4)+(radius/2));
+  context.quadraticCurveTo(0, (centerY*-1)*1.5, linelen, centerY+(curGlyph.height / 4)+(radius/2));
+  context.stroke();
+  context.closePath();
+
+  // Small left arc
+  context.beginPath();
+  // Arc length should be slightly reduced, but I don't know the formula
+  context.arc(linelen * -1 + context.lineWidth/4, 0, radius/2, 0.5 * Math.PI, 1.5 * Math.PI, false);
+  context.stroke();
+  context.closePath();
+
+  // Small right arc
+  context.beginPath();
+  context.arc(linelen - context.lineWidth/4, 0, radius/2, 0.5 * Math.PI, 1.5 * Math.PI, true);
+  context.stroke();
+  context.closePath();
+
+  // Large left arc
+  context.beginPath();
+  context.moveTo(centerY+(curGlyph.height / 4)-(radius/2), linelen * -1);
+  context.quadraticCurveTo(centerY*1.5, 0, centerY+(curGlyph.height / 4)-(radius/2), linelen);
+  context.stroke();
+  context.closePath();
+
+  // Large right arc
+  context.beginPath();
+  context.moveTo(centerY+(curGlyph.height / 4)+(radius/2), linelen * -1);
+  context.quadraticCurveTo((centerY*-1)*1.5, 0, centerY+(curGlyph.height / 4)+(radius/2), linelen);
+  context.stroke();
+  context.closePath();
+
+  // Small top arc
+  context.beginPath();
+  context.arc(0, linelen * -1 + context.lineWidth/4, radius/2, 0.0 * Math.PI, 1.0 * Math.PI, true);
+  context.stroke();
+  context.closePath();
+
+  // Small bottom arc
+  context.beginPath();
+  context.arc(0, linelen * 1 - context.lineWidth/4, radius/2, 0.0 * Math.PI, 1.0 * Math.PI, false);
+  context.stroke();
+  context.closePath();
+
+  context.beginPath();
+  context.arc(centerX, 0, radius/2, 0, 2.0 * Math.PI, false);
+  context.arc(centerX, 0, radius/4, 0, 2.0 * Math.PI, false);
+  context.arc(centerX, 0, radius/8, 0, 2.0 * Math.PI, false);
+  context.stroke();
+  context.closePath();
+
+  // make alpha solid (the color doesn't matter)
+  context.fillStyle = 'rgba(255,255,255,0.0)';
+
+  // change composite mode and fill
+  context.globalCompositeOperation = 'destination-out';
+  context.fill();
+  context.restore();
+
+  // reset composite mode to default
+}
+
+// Symbol for Poseidon (modified)
+function drawGlyph5(elem = document.getElementById('tile c5')) {
+  if (elem === undefined || elem === null) return;
+  var curGlyph = elem; // 1 specific tile
+  var context = curGlyph.getContext('2d');
+
+  const centerX = 0;
+  const centerY = -1 * (curGlyph.height / 8);
+  const radius = (curGlyph.height / 4);
+  const linelen = 2.5 * (curGlyph.height / 8);
+  const lineWidth = (curGlyph.height / 16);
+  const glyphForeground = 'rgba(255,255,255,1.0)';
+  let glyphBackground = 'rgba(230,150,184,1.0)';
+  let cssBg = getCssBg(".c5");
+
+  if (cssBg.length > 0) glyphBackground = cssBg;
+
+  context.clearRect(0, 0, window.innerWidth,window.innerHeight);
+
+  context.fillStyle = glyphBackground;
+  context.fillRect(0,0,window.innerWidth,window.innerHeight);
+
+  context.save();
+  context.translate(curGlyph.width / 2, curGlyph.height / 2);
+
+  context.scale(1.0, 1.0);
+  context.lineWidth = lineWidth;
+  context.strokeStyle = glyphForeground;
+
+  // define the arc path
+  context.beginPath();
+  context.arc(centerX, centerY*-1+(curGlyph.height / 4), radius, 0, 1.0 * Math.PI, true);
+  context.stroke();
+  context.closePath();
+  context.beginPath();
+  context.moveTo(linelen * -1, 0);
+  context.lineTo(linelen, 0);
+  context.stroke();
+  context.closePath();
+  context.beginPath();
+  context.moveTo(centerX, centerY-(curGlyph.height / 4)+radius);
+  context.lineTo(centerX, centerY*-1+(curGlyph.height / 4)-radius);
+  context.stroke();
+  context.closePath();
+  context.beginPath();
+  context.arc(centerX, centerY-(curGlyph.height / 4), radius, 0, 1.0 * Math.PI, false);
+
+  // stroke it
+  context.stroke();
+
+  // make alpha solid (the color doesn't matter)
+  context.fillStyle = 'rgba(255,255,255,0.0)';
+
+  // change composite mode and fill
+  context.globalCompositeOperation = 'destination-out';
+  context.fill();
+  context.restore();
+
+  // reset composite mode to default
+}
+
+// Symbol for Pluto
+function drawGlyph6(elem = document.getElementById('tile c6')) {
+  if (elem === undefined || elem === null) return;
+  var curGlyph = elem; // 1 specific tile
+  var context = curGlyph.getContext('2d');
+
+  const centerX = 0;
+  const centerY = -1 * (curGlyph.height / 8);
+  const radius = (curGlyph.height / 4);
+  const linelen = 2.5 * (curGlyph.height / 8);
+  const lineWidth = (curGlyph.height / 16);
+  const glyphForeground = 'rgba(255,255,255,1.0)';
+  let glyphBackground = 'rgba(230,187,150,1.0)';
+  let cssBg = getCssBg(".c6");
+
+  if (cssBg.length > 0) glyphBackground = cssBg;
+
+  context.clearRect(0, 0, window.innerWidth,window.innerHeight);
+
+  context.fillStyle = glyphBackground;
+  context.fillRect(0,0,window.innerWidth,window.innerHeight);
+
+  context.save();
+  context.translate(curGlyph.width / 2, curGlyph.height / 2);
+
+  context.scale(1.0, 1.0);
+  context.lineWidth = lineWidth;
+  context.strokeStyle = glyphForeground;
+
+  // define the arc path
+  context.beginPath();
+  context.arc(centerX, 0-radius, radius/2, 0, 2.0 * Math.PI, false);
+  context.stroke();
+  context.closePath();
+  context.beginPath();
+  context.arc(centerX, 0-radius, radius, 0, 1.0 * Math.PI, false);
+  context.stroke();
+  context.closePath();
+  context.beginPath();
+  context.moveTo(radius/2 * -1, (centerY+(curGlyph.height / 4)+radius)/2);
+  context.lineTo(radius/2, (centerY+(curGlyph.height / 4)+radius)/2);
+  context.stroke();
+  context.closePath();
+  context.beginPath();
+  context.moveTo(centerX, 0);
+  context.lineTo(centerX, centerY+(curGlyph.height / 4)+radius);
+  context.stroke();
+  context.closePath();
+
+  // make alpha solid (the color doesn't matter)
+  context.fillStyle = 'rgba(255,255,255,0.0)';
+
+  // change composite mode and fill
+  context.globalCompositeOperation = 'destination-out';
+  context.fill();
+  context.restore();
+
+  // reset composite mode to default
+}
+
+// Bow tie (Modified) aka Butterfly
+function drawGlyph7(elem = document.getElementById('tile c7')) {
+  if (elem === undefined || elem === null) return;
+  var curGlyph = elem; // 1 specific tile
+  var context = curGlyph.getContext('2d');
+
+  const centerX = 0;
+  const centerY = 0;
+  const radius = (curGlyph.height / 4);
+  const linelen = 2.5 * (curGlyph.height / 8);
+  const lineWidth = (curGlyph.height / 16);
+  const glyphForeground = 'rgba(255,255,255,1.0)';
+  let glyphBackground = 'rgba(168,198,29,1.0)';
+  let cssBg = getCssBg(".c7");
+
+  if (cssBg.length > 0) glyphBackground = cssBg;
+
+  context.clearRect(0, 0, window.innerWidth,window.innerHeight);
+
+  context.fillStyle = glyphBackground;
+  context.fillRect(0,0,window.innerWidth,window.innerHeight);
+
+  context.save();
+  context.translate(curGlyph.width / 2, curGlyph.height / 2);
+
+  context.scale(1.0, 1.0);
+  context.lineWidth = lineWidth;
+  context.strokeStyle = glyphForeground;
+
+  // define the glyph path(s)
+  context.beginPath();
+  context.moveTo(linelen * -1, -1 * linelen);
+  context.lineTo(linelen, linelen);
+  context.lineTo(linelen, -1 * linelen);
+  context.lineTo(linelen * -1, linelen);
+  context.lineTo(linelen * -1, -1 * linelen);
+  context.lineTo(linelen, linelen);
+  context.stroke();
+  context.closePath();
+  context.beginPath();
+  context.moveTo(-1 * (curGlyph.width/8), -1 * radius - context.lineWidth/2);
+  context.lineTo(0, -1 * (curGlyph.height/8)*1.25);
+  context.lineTo((curGlyph.width/8), -1 * radius - context.lineWidth/2);
+  context.stroke();
+  context.closePath();
+  context.beginPath();
+  context.moveTo(-1 * (curGlyph.width/8), radius + context.lineWidth/2);
+  context.lineTo(0, (curGlyph.height/8)*1.25);
+  context.lineTo((curGlyph.width/8), radius + context.lineWidth/2);
+  context.stroke();
+  context.closePath();
+  context.beginPath(); // It is easier to overwrite white lines
+  context.fillStyle = glyphBackground;
+  context.strokeStyle = glyphBackground;
+  context.arc(centerX, centerY, radius/4, 0, 2.0 * Math.PI, false);
+  context.arc(centerX, centerY, radius/8, 0, 2.0 * Math.PI, false);
+  context.stroke();
+  context.closePath();
+  context.beginPath();
+  context.strokeStyle = glyphForeground;
+  context.arc(centerX, centerY, radius/2, 0, 2.0 * Math.PI, false);
+  context.stroke();
+  context.closePath();
+
+  // make alpha solid (the color doesn't matter)
+  context.fillStyle = 'rgba(255,255,255,0.0)';
+
+  // change composite mode and fill
+  context.globalCompositeOperation = 'destination-out';
+  context.fill();
+  context.restore();
+
+  // reset composite mode to default
+}
+
+// Japanese Torii Gate (Simplified)
+function drawGlyph8(elem = document.getElementById('tile c8')) {
+  if (elem === undefined || elem === null) return;
+  var curGlyph = elem; // 1 specific tile
+  var context = curGlyph.getContext('2d');
+
+  const centerX = 0;
+  const centerY = -1 * (curGlyph.height / 8);
+  const radius = (curGlyph.height / 4);
+  const linelen1 = 3.0 * (curGlyph.height / 8);
+  const linelen2 = 2.5 * (curGlyph.height / 8);
+  const linelen3 = 1.6 * (curGlyph.height / 8);
+  const lineWidth = (curGlyph.height / 16);
+  const glyphForeground = 'rgba(255,255,255,1.0)';
+  let glyphBackground = 'rgba(132,224,146,1.0)';
+  let cssBg = getCssBg(".c8");
+
+  if (cssBg.length > 0) glyphBackground = cssBg;
+
+  context.clearRect(0, 0, window.innerWidth,window.innerHeight);
+
+  context.fillStyle = glyphBackground;
+  context.fillRect(0,0,window.innerWidth,window.innerHeight);
+
+  context.save();
+  context.translate(curGlyph.width / 2, curGlyph.height / 2);
+
+  context.scale(1.0, 1.0);
+  context.lineWidth = lineWidth;
+  context.strokeStyle = glyphForeground;
+
+  // define the glyph path(s)
+  context.beginPath();
+  context.moveTo(linelen1 * -1, -1 * (centerY+(curGlyph.height / 4)+radius));
+  context.lineTo(linelen1, -1 * (centerY+(curGlyph.height / 4)+radius));
+  context.stroke();
+  context.closePath();
+  context.beginPath();
+  context.moveTo(linelen2 * -1, -1 * (centerY+(curGlyph.height / 4)+radius)/2);
+  context.lineTo(linelen2, -1 * (centerY+(curGlyph.height / 4)+radius)/2);
+  context.stroke();
+  context.closePath();
+  context.beginPath();
+  context.moveTo(linelen3 * -1, -1 * (centerY+(curGlyph.height / 4)+radius));
+  context.lineTo(linelen3 * -1, centerY+(curGlyph.height / 4)+radius);
+  context.stroke();
+  context.closePath();
+  context.beginPath();
+  context.moveTo(linelen3, -1 * (centerY+(curGlyph.height / 4)+radius));
+  context.lineTo(linelen3, centerY+(curGlyph.height / 4)+radius);
+  context.stroke();
+  context.closePath();
+
+  // make alpha solid (the color doesn't matter)
+  context.fillStyle = 'rgba(255,255,255,0.0)';
+
+  // change composite mode and fill
+  context.globalCompositeOperation = 'destination-out';
+  context.fill();
+  context.restore();
+
+  // reset composite mode to default
+}
+
+// triangle green glyph (unused?)
+function drawGlyph9(elem = document.getElementById('tile c9')) {
+  if (elem === undefined || elem === null) return;
+  var curGlyph = elem; // 1 specific tile
+  var context = curGlyph.getContext('2d');
+
+  const centerX = 0;
+  const centerY = -1 * (curGlyph.height / 4);
+  const radius = (curGlyph.height / 6);
+  const linelen = 3 * (curGlyph.height / 8);
+  const lineWidth = (curGlyph.height / 16);
+  const glyphForeground = 'rgba(255,255,255,1.0)';
+  let glyphBackground = 'rgba(0,255,0,1.0)';
+  let cssBg = getCssBg(".c9");
+
+  if (cssBg.length > 0) glyphBackground = cssBg;
+
+  context.clearRect(0, 0, window.innerWidth,window.innerHeight);
+
+  context.fillStyle = glyphBackground;
+  context.fillRect(0,0,window.innerWidth,window.innerHeight);
+
+  context.save();
+  context.translate(curGlyph.width / 2, curGlyph.height / 2);
+
+  context.scale(1.0, 1.0);
+  context.lineWidth = lineWidth;
+  context.strokeStyle = glyphForeground;
+
+  // define the glyph path(s)
+  context.beginPath();
+  context.moveTo(0, -1 * linelen);
+  context.lineTo(linelen * -1, linelen);
+  context.lineTo(linelen, linelen);
+  context.lineTo(0, -1 * linelen);
+  context.stroke();
+  context.closePath();
+  context.beginPath();
+  context.strokeStyle = glyphForeground;
+  context.arc(centerX, linelen/2-radius/3, radius/2, 0, 2.0 * Math.PI, false);
+  context.stroke();
+  context.closePath();
+
+  // make alpha solid (the color doesn't matter)
+  context.fillStyle = 'rgba(255,255,255,0.0)';
+
+  // change composite mode and fill
+  context.globalCompositeOperation = 'destination-out';
+  context.fill();
+  context.restore();
+
+  // reset composite mode to default
+}
+
+// chevron magenta glyph (unused?)
+function drawGlyph10(elem = document.getElementById('tile c10')) {
+  if (elem === undefined || elem === null) return;
+  var curGlyph = elem; // 1 specific tile
+  var context = curGlyph.getContext('2d');
+
+  const centerX = 0;
+  const centerY = -1 * (curGlyph.height / 4);
+  const radius = (curGlyph.height / 6);
+  const linelen = 3 * (curGlyph.height / 8);
+  const lineWidth = (curGlyph.height / 16);
+  const glyphForeground = 'rgba(255,255,255,1.0)';
+  let glyphBackground = 'rgba(255,0,255,1.0)';
+  let cssBg = getCssBg(".c10");
+
+  if (cssBg.length > 0) glyphBackground = cssBg;
+
+  context.clearRect(0, 0, window.innerWidth,window.innerHeight);
+
+  context.fillStyle = glyphBackground;
+  context.fillRect(0,0,window.innerWidth,window.innerHeight);
+
+  context.save();
+  context.translate(curGlyph.width / 2, curGlyph.height / 2);
+
+  context.scale(1.0, 1.0);
+  context.lineWidth = lineWidth;
+  context.strokeStyle = glyphForeground;
+
+  // define the glyph path(s)
+  context.beginPath();
+  context.moveTo(0, -1 * linelen);
+  context.lineTo(linelen * -1, 0);
+  context.lineTo(linelen * -1, linelen);
+  context.lineTo(0, 0);
+  context.lineTo(linelen, linelen);
+  context.lineTo(linelen, 0);
+  context.lineTo(0, -1 * linelen);
+  context.stroke();
+  context.closePath();
+  context.beginPath();
+  context.strokeStyle = glyphForeground;
+  context.arc(centerX, linelen/-2 + radius/4, radius/2, 0, 2.0 * Math.PI, false);
+  context.stroke();
+  context.closePath();
+
+  // make alpha solid (the color doesn't matter)
+  context.fillStyle = 'rgba(255,255,255,0.0)';
+
+  // change composite mode and fill
+  context.globalCompositeOperation = 'destination-out';
+  context.fill();
+  context.restore();
+
+  // reset composite mode to default
+}
+
+// Populate the color selector with glyphs too:
+drawGlyphByNum(-1);
+drawGlyphByNum(0);
+drawGlyphByNum(1);
+drawGlyphByNum(2);
+drawGlyphByNum(3);
+drawGlyphByNum(4);
+drawGlyphByNum(5);
+drawGlyphByNum(6);
+drawGlyphByNum(7);
+drawGlyphByNum(8);
+drawGlyphByNum(9);
+drawGlyphByNum(10);
+
+

--- a/website/website.js
+++ b/website/website.js
@@ -431,7 +431,7 @@ async function importBoard(e) {
   let importJSONString = "";
 
   if (puzerr !== null) {
-    puzerr.innerHTML = "";  New import means no errors, yet!
+    puzerr.innerHTML = "";  // New import means no errors, yet!
   }
   // Read JSON from clipboard
   try {


### PR DESCRIPTION
  Current pallet may make some glyphs difficult to see.
  Effort has been made to make these Islands of Insight copyright/trademark safe glyphs.
  https://jsfiddle.net/5gawy0np/20/ was used as a scratchpad.
  All glyphs scale according to their HTML5 canvas size (Y-axis) and were developed as 256px x 256px
  Glyphs require a Canvas and I do not yet know how to handle hover, so that is lost.
  See: https://stackoverflow.com/questions/29300280/update-html5-canvas-rectangle-on-hover
Allow toggling on/off of currently selected tool/color/glyph (selected glyph vs white).
  Selected glyph has to match existing tile to toggle.
Get color pallet from CSS (external style sheet); Won't work with "file:///" in Chrome. 
Fixed an HTML validation complaint for INPUT fields.